### PR TITLE
Prompt for key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ an authentication token must be generated and recorded as documented below in or
 https://www.terraform.io/docs/commands/cli-config.html
 
 # Setup
+Create a *.tfvars file (e.g. secrets.tfvars) with the following:
+```hcl
+ec2_key_name = "<NAME OF AWS EC2 KEY PAIR TO USE FOR INSTANCE ACCESS>"
+
 You will need to build the demo out in stages
 ```hcl
 terraform init

--- a/variables.tf
+++ b/variables.tf
@@ -27,5 +27,5 @@ variable "allowed_app_cidr" {
 }
 
 variable "ec2_key_name" {
-  default = "cody-key"
+  description = "name of AWS EC2 key pair to use for access to provisioned instances"
 }


### PR DESCRIPTION
by removing the default the user will be prompted for the key name to use in their AWS account (unless they defined it in a tfvars file). Otherwise the build will fail after resources have been built.