### PR TITLE
[MERGE BEFORE #10] Destroy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ terraform init
 terraform apply -target module.vpc -target module.nginx-demo-app -target module.bigip -target module.bigip_sg -target module.bigip_mgmt_sg -target module.demo_app_sg
 terraform apply
 ```
+
+When you are done using the demo environment you will need to decommission in stages
+```hcl
+terraform destroy -target bigip_as3.as3-demo1 -target bigip_as3.as3-demo2
+terraform destroy -target module.nginx-demo-app
+terraform apply -target module.vpc -target module.bigip -target module.bigip_sg -target module.bigip_mgmt_sg -target module.demo_app_sg
+```
+terraform destroy -target bigip_as3.as3-demo1 -target bigip_as3.as3-demo2

--- a/README.md
+++ b/README.md
@@ -38,6 +38,5 @@ When you are done using the demo environment you will need to decommission in st
 ```hcl
 terraform destroy -target bigip_as3.as3-demo1 -target bigip_as3.as3-demo2
 terraform destroy -target module.nginx-demo-app
-terraform apply -target module.vpc -target module.bigip -target module.bigip_sg -target module.bigip_mgmt_sg -target module.demo_app_sg
+terraform destroy -target module.vpc -target module.bigip -target module.bigip_sg -target module.bigip_mgmt_sg -target module.demo_app_sg
 ```
-terraform destroy -target bigip_as3.as3-demo1 -target bigip_as3.as3-demo2


### PR DESCRIPTION
THESE INSTRUCTIONS APPLY TO USING MODULE v0.1.1. - merge this and create a v0.1.1.1 tag (or something like it) before merging #10 and creating a v0.1.2 tag/release

Because of the interdependencies between the bigip provider and the AWS instance hosting the bigip the environment needs to be destroyed in stages. This is essentially the build process in reverse.