### PR TITLE
include AS3 operability test

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,6 @@ terraform destroy -target bigip_as3.as3-demo1 -target bigip_as3.as3-demo2
 # remove the nginx demo application nodes
 terraform destroy -target module.nginx-demo-app
 # remove the BIG-IP and the underpinning infrastructure
-terraform destroy -target module.vpc -target module.bigip -target module.bigip_sg -target module.bigip_mgmt_sg -target module.demo_app_sg -target aws_secretsmanager_secret_version.bigip-pwd
+terraform destroy -target module.vpc -target module.bigip -target module.bigip_sg -target module.bigip_mgmt_sg -target module.demo_app_sg -target aws_secretsmanager_secret_version.bigip-pwd -target random_password.password -target random_id.id -target aws_secretsmanager_secret.bigip
 ```
 

--- a/findthehosts.sh
+++ b/findthehosts.sh
@@ -1,0 +1,4 @@
+export BIGIPHOST0=`terraform output --json | jq -r '.bigip_mgmt_public_ips.value[0]'`
+export BIGIPMGMTPORT=`terraform output --json | jq -r '.bigip_mgmt_port.value'`
+export BIGIPPASSWORD=`terraform output --json | jq -r '.bigip_password.value'`
+echo connect at https://$BIGIPHOST0:$BIGIPMGMTPORT with $BIGIPPASSWORD

--- a/inspec/bigip-ready/controls/example.rb
+++ b/inspec/bigip-ready/controls/example.rb
@@ -17,17 +17,18 @@ control "Connectivity" do
   title "BIGIP is reachable"
 
   BIGIP_DNS.each do |bigip_host|
+    # can we reach the management port on the BIG-IP?
     describe host(bigip_host, port: BIGIP_PORT, protocol: 'tcp') do
         it { should be_reachable }
     end
-    testurl = 'https://' + bigip_host + ':' + BIGIP_PORT + '/mgmt/shared/appsvcs/info'
-    describe http(testurl,
+    # is the application services end point available?
+    describe http("https://#{bigip_host}:#{BIGIP_PORT}/mgmt/shared/appsvcs/info",
               auth: {user: 'admin', pass: BIGIP_PASSWORD},
               params: {format: 'html'},
               method: 'GET',
               ssl_verify: false) do
           its('status') { should cmp 200 }
-          its('body') { should match 'version' }
+          its('body') { should match 'version' } # this should be replaced with a more nuanced set of tests
           its('headers.Content-Type') { should match 'application/json' }
     end
   end

--- a/inspec/bigip-ready/controls/example.rb
+++ b/inspec/bigip-ready/controls/example.rb
@@ -10,6 +10,7 @@ params = JSON.parse(content)
 
 BIGIP_DNS  = params['bigip_mgmt_public_ips']['value']
 BIGIP_PORT = params['bigip_mgmt_port']['value']
+BIGIP_PASSWORD  = params['bigip_password']['value']
 
 control "Connectivity" do
   impact 1.0
@@ -19,7 +20,16 @@ control "Connectivity" do
     describe host(bigip_host, port: BIGIP_PORT, protocol: 'tcp') do
         it { should be_reachable }
     end
-    # TODO: include testing of authentication against API
+    testurl = 'https://' + bigip_host + ':' + BIGIP_PORT + '/mgmt/shared/appsvcs/info'
+    describe http(testurl,
+              auth: {user: 'admin', pass: BIGIP_PASSWORD},
+              params: {format: 'html'},
+              method: 'GET',
+              ssl_verify: false) do
+          its('status') { should cmp 200 }
+          its('body') { should match 'version' }
+          its('headers.Content-Type') { should match 'application/json' }
+    end
   end
 end 
 

--- a/runlocust.sh
+++ b/runlocust.sh
@@ -1,0 +1,6 @@
+# find the ip address of the created BIG-IP 
+export BIGIPHOST0=`terraform output --json | jq -r '.bigip_mgmt_public_ips.value[0]'`
+# start the locust instance 
+cd locust
+locust --host=http://$BIGIPHOST0
+cd ..

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,2 @@
+terraform output --json > inspec/bigip-ready/files/terraform.json
+inspec exec inspec/bigip-ready


### PR DESCRIPTION
extends the inspec test to perform basic verification of the AS3 service as described at https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/userguide/installation.html#checking-for-a-successful-installation